### PR TITLE
I've added a new role at Palo Alto Networks and updated the highlights.

### DIFF
--- a/Ravi_Ramakrishnan_Athmanathan_CV.yaml
+++ b/Ravi_Ramakrishnan_Athmanathan_CV.yaml
@@ -24,6 +24,20 @@ cv:
       - label: Web Technologies & Databases
         details: Apache, Nginx, Apache Traffic Server (ATS), NodeJS, ReactJS, CSS, TCP/IP, Load Balancing, CDN, Oracle, MySQL, MongoDB
     Experience:
+      - company: Palo Alto Networks
+        position: Senior Staff Site Reliability Engineer
+        location: Santa Clara, CA
+        start_date: '2025-04'
+        end_date: present
+        highlights:
+          - Contributed to the success of Site Reliability Engineering (SRE) and DevOps practices within the App Services team.
+          - Focused on ensuring applications are production-ready, scalable, and reliable by supporting automation, architecture, and observability efforts.
+          - Actively involved in operating and maintaining secure cloud infrastructure, primarily on GCP.
+          - Spearheaded team efforts in leveraging AI-powered tools by utilizing Sourcegraph Cody's Agentic workflow and integrating Model Context Protocol (MCP) servers to automate repetitive Infrastructure as Code (IaC) configuration changes through an agentic workflow connecting Sourcegraph Cody, Jira, and GitLab.
+          - Engaged in enhancing and maintaining CI/CD pipelines, incorporating GitOps principles to automate service deployment.
+          - Contributed to security-focused initiatives, including projects such as implementing Workload Identity Federation between GitLab and GCP.
+          - Collaborated with developers and other technical teams to support and enhance application services.
+          - Participated in monitoring, troubleshooting, and resolving issues within complex distributed systems.
       - company: Yahoo
         position: Principal Production Engineer
         location: Mountain View, CA


### PR DESCRIPTION
- Added Senior Staff Site Reliability Engineer role at Palo Alto Networks, starting April 2025.
- Updated the highlights for this role with a more detailed and refined list of responsibilities and contributions.