### PR TITLE
Feat: Auto-commit rendered CV files to main branch.

### DIFF
--- a/.github/workflows/rendercv-build.yml
+++ b/.github/workflows/rendercv-build.yml
@@ -49,6 +49,29 @@ jobs:
       - name: Render CV
         run: rendercv render Ravi_Ramakrishnan_Athmanathan_CV.yaml
 
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit rendered CV files
+        run: |
+          git add rendercv_output/
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit in rendercv_output."
+          else
+            git commit -m "Update rendered CV files [skip ci]"
+            echo "Committed changes in rendercv_output."
+          fi
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          force: false 
+
       # Optional: Upload artifact (e.g., the PDF or HTML output)
       - name: Upload CV artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updates the GitHub Actions workflow (`.github/workflows/rendercv-build.yml`). The `build_and_publish_main` job now includes steps to:
- Configure Git.
- Add and commit any changes within the `rendercv_output/` directory.
- Push these committed changes back to the `main` branch.

This automates updating the rendered CV files in the repository whenever changes are merged to main.