### PR TITLE
Here's the fix: I've granted `contents:write` permission to the workf…

### DIFF
--- a/.github/workflows/rendercv-build.yml
+++ b/.github/workflows/rendercv-build.yml
@@ -32,6 +32,8 @@ jobs:
   build_and_publish_main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
…low job for push operations.

I've updated the `build_and_publish_main` job in your GitHub Actions workflow to include `permissions: contents: write`. This will give the GITHUB_TOKEN the necessary permissions to push committed changes back to the main branch, which should resolve the 403 error you were seeing.