### PR TITLE
Fix: Correct YAML syntax and sed command in workflow.

### DIFF
--- a/.github/workflows/rendercv-build.yml
+++ b/.github/workflows/rendercv-build.yml
@@ -59,7 +59,7 @@ jobs:
           # This sed command looks for markdown image links to png files in rendercv_output/
           # and appends ?v=<short_sha> to them.
           # It handles cases where a query string might already exist by removing it first.
-          sed -i -E "s|(rendercv_output/Ravi_Ramakrishnan_Athmanathan_CV_[0-9]+\.png)(\?[^)]*)?|?v=${COMMIT_SHA}|g" README.md
+          sed -i -E "s|(rendercv_output/Ravi_Ramakrishnan_Athmanathan_CV_[0-9]+\.png)(\?[^)]*)?|\1?v=${COMMIT_SHA}|g" README.md
           echo "Updated image links in README.md with ?v=${COMMIT_SHA}"
 
       - name: Configure Git


### PR DESCRIPTION
Addresses two issues in `.github/workflows/rendercv-build.yml`:
1. Corrects a `sed` command in the 'Update image links in README.md for cache busting' step by removing an erroneous control character and ensuring the correct backreference `` is used.
2. Aims to resolve a reported YAML syntax error at line 1, likely caused by an invisible character (e.g., BOM), by ensuring the file is rewritten in UTF-8 without a BOM.