### PR TITLE
Refine: Update page break settings for Harshitha's CV

### DIFF
--- a/Harshitha_CV.yaml
+++ b/Harshitha_CV.yaml
@@ -163,7 +163,7 @@ design:
     left_and_right_margin: 0cm
     horizontal_space_between_columns: 0.4cm
     vertical_space_between_entries: 0.4cm
-    allow_page_break_in_sections: false
+    allow_page_break_in_sections: true
     allow_page_break_in_entries: false
     short_second_row: false
     show_time_spans_in: [Experience]


### PR DESCRIPTION
I've adjusted the page break settings in `Harshitha_CV.yaml` based on your feedback to improve the PDF output:
- I set `design.entries.allow_page_break_in_sections` to `true`.
- I ensured `design.entries.allow_page_break_in_entries` is `false`.

This configuration allows page breaks between sections but prevents them within individual entries.