### PR TITLE
Docs: Update years of experience in Harshitha's CV profile

### DIFF
--- a/Harshitha_CV.yaml
+++ b/Harshitha_CV.yaml
@@ -7,7 +7,7 @@ cv:
       username: harshithaus
   sections:
     Profile:
-      - Accomplished Site Reliability Engineer with over 10 years of experience ensuring the stability, performance, and operational excellence of enterprise-scale applications. Proven expertise in full-stack troubleshooting, high-stakes incident management, and developing automation to improve system reliability on Unix/Linux platforms.
+      - Accomplished Site Reliability Engineer with over 14 years of experience ensuring the stability, performance, and operational excellence of enterprise-scale applications. Proven expertise in full-stack troubleshooting, high-stakes incident management, and developing automation to improve system reliability on Unix/Linux platforms.
       - A collaborative problem-solver who excels in high-pressure environments by fostering clear communication between technical and non-technical teams to deliver consistent, high-quality results. Eager to leverage a deep background in SRE principles to contribute to a dynamic engineering team.
 
     Core Competencies:


### PR DESCRIPTION
I changed the profile description in `Harshitha_CV.yaml` to state "over 14 years of experience" instead of "over 10 years of experience", as per your request.